### PR TITLE
fixed a routing error after adding a post

### DIFF
--- a/client/views/singlePost.js
+++ b/client/views/singlePost.js
@@ -172,6 +172,8 @@ Template.newPost.events({
         // XXX: what errors are possible here?
         console.log(err.reason);
       } else {
+        self.publishedAt = new Date();
+        self.slug = titleToSlug(self.title);
         Meteor.Router.navigate(Routes.postUrl(self), {trigger: true});
       }
     })


### PR DESCRIPTION
Hi, when saving or saving and publishing new blog posts, the app keeps getting rerouted to 
    /NaN/NaN/NaN/undefined 
path, causing an exception:

```
Exception from Deps recompute: TypeError: Cannot read property '_id' of undefined
    at http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:13:15980
    at LocalCollection.Cursor.forEach (http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:3:16418)
    at Template.singlePost.helpers.prevPost (http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:13:15951)
    at a (http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:9:11813)
    at s (http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:9:11975)
    at http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:9:12875
    at Object.Spark.labelBranch (http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:8:31544)
    at f (http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:9:12443)
    at http://www.airseasummit.com/6a7a47e4a744d7473875010d2cb131ab65a9255a.js:9:12848
    at Array.forEach (native) 
```

Please find the screen shot attached,
![screen shot 2013-08-11 at 1 01 34 pm](https://f.cloud.github.com/assets/53909/943682/91e062f8-024b-11e3-9fa0-984cbd1c6983.png)

After looking around, I attempted to fix this issue by including `publishedAt` and `slug` fields to the Post before rerouting to it. This seems to do the job.
